### PR TITLE
feat: Add all available MSK brokers to the tunnel pool

### DIFF
--- a/Instance.py
+++ b/Instance.py
@@ -53,7 +53,6 @@ class AWSMSKInstances:
         client = self.session.client('kafka')
         cluster_info = client.describe_cluster(ClusterArn=cluster_arn)['ClusterInfo']
         brokers_info = client.get_bootstrap_brokers(ClusterArn=cluster_arn)
-        print(brokers_info)
 
         hosts_as_string = ""
         if 'BootstrapBrokerString' in brokers_info:
@@ -61,7 +60,16 @@ class AWSMSKInstances:
         if 'BootstrapBrokerStringSaslScram' in brokers_info:
             hosts_as_string = brokers_info['BootstrapBrokerStringSaslScram']
 
-        hosts_as_string = hosts_as_string + "," + cluster_info['ZookeeperConnectString']
+        hosts = hosts_as_string.split(',')
+        host_as_string = hosts[0].split('.')
+        connection_hosts = []
+        i = 1
+        while i <= cluster_info['NumberOfBrokerNodes']:
+            connection_hosts.append("b-" + str(i)+"."+".".join(host_as_string))
+            i += 1
+
+        hosts_as_string = ",".join(connection_hosts) + "," + cluster_info['ZookeeperConnectString']
+
         instances = []
         for row in hosts_as_string.split(','):
             [host, port] = row.split(':')

--- a/Instance.py
+++ b/Instance.py
@@ -1,4 +1,5 @@
 import boto3
+import socket
 
 class Instance:
     def __init__(self, name, ip, port):
@@ -17,7 +18,7 @@ class ManualInstances(RetrieveInstanceIPs):
             instances.append(Instance(name=service,ip=ip,port=port))
         return instances
 
-class AWSInstances(RetrieveInstanceIPs):
+class AWSEC2Instances(RetrieveInstanceIPs):
     def __init__(self,profile,region):
         self.profile = profile
         self.region = region
@@ -38,3 +39,33 @@ class AWSInstances(RetrieveInstanceIPs):
                 if ip is not None:
                   ips.append(instance.get(u'PrivateIpAddress'))
         return ips
+
+
+class AWSMSKInstances:
+    def __init__(self, region):
+        self.region = region
+        self.session = boto3.Session(region_name=region)
+
+    def set_aws_profile(self, profile):
+        self.session = boto3.Session(profile_name=profile, region_name=self.session.region_name)
+
+    def get_instances(self, cluster_arn):
+        client = self.session.client('kafka')
+        cluster_info = client.describe_cluster(ClusterArn=cluster_arn)['ClusterInfo']
+        brokers_info = client.get_bootstrap_brokers(ClusterArn=cluster_arn)
+        print(brokers_info)
+
+        hosts_as_string = ""
+        if 'BootstrapBrokerString' in brokers_info:
+            hosts_as_string = brokers_info['BootstrapBrokerString']
+        if 'BootstrapBrokerStringSaslScram' in brokers_info:
+            hosts_as_string = brokers_info['BootstrapBrokerStringSaslScram']
+
+        hosts_as_string = hosts_as_string + "," + cluster_info['ZookeeperConnectString']
+        instances = []
+        for row in hosts_as_string.split(','):
+            [host, port] = row.split(':')
+            ip = socket.gethostbyname(host)
+            instances.append(Instance(host, ip, port))
+
+        return instances

--- a/Instance.py
+++ b/Instance.py
@@ -62,6 +62,7 @@ class AWSMSKInstances:
 
         hosts = hosts_as_string.split(',')
         host_as_string = hosts[0].split('.')
+        host_as_string.pop(0)
         connection_hosts = []
         i = 1
         while i <= cluster_info['NumberOfBrokerNodes']:

--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ On a second screen just do whatever you want, e.g. list all topics.
 ```bash
 $ kafka-topics --zookeeper 10.11.85.128:2181 --list
 ```
+
+* on a AWS MSK cluster
+
+```bash
+$ kafkatunnel msk ec2-user@awsjumphost arn:aws:kafka:...
+```


### PR DESCRIPTION
When connecting to MSK we must get a list of brokers to connect too.
The AWS tooling for this only returns _some_ of the active brokers, this means both the tunnel and the application must both connect to the same brokers each time, which doesn't happen that often.

Using the broker pool number, construct the endpoint host for the amount of brokers we have and open a tunnel for each one.
